### PR TITLE
 Changing rule to "make pandas/dist/<>.tar.gz"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ make tag
 make docker-image docker-doc
 
 # Build the sdist
-make pandas/dist/<>.sdist
+make pandas/dist/<>.tar.gz
 
 # Final Pip and Conda tests. Do these in parallel.
 # You can optionally do make doc here as well


### PR DESCRIPTION
I was trying to build pandas based on the instructions in README.md
the rule ` make pandas/dist/<>.sdist ` failed because as per my understanding the extension has to be .tar.gz rather than .dist. as dictated by `TARGZ=pandas-$(PANDAS_VERSION).tar.gz
`