### PR TITLE
remove typo in environment.yml package name 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,6 @@ dependencies:
     - packaging
     - conda-build
     - conda-smithy
-    - conda-forge-pinnings
+    - conda-forge-pinning
     - lxml
     - twine


### PR DESCRIPTION
got an error when creating env, there was a trailing 's' in the 'conda-forge-pinning' now removed