### PR TITLE
update for 1.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # TO EDIT
-TAG ?= v1.0.2
+TAG ?= v1.0.3
+
 GH_USERNAME ?= TomAugspurger
 PANDAS_VERSION=$(TAG:v%=%)
 PANDAS_BASE_VERSION=$(shell echo $(PANDAS_VERSION) | awk -F '.' '{OFS="."} { print $$1, $$2}')
@@ -70,7 +71,7 @@ conda-test:
 		-v ${CURDIR}/pandas:/pandas \
 		-v ${CURDIR}/recipe:/recipe \
 		pandas-build \
-		sh -c "conda build --numpy=1.13 --python=3.6 /recipe --output-folder=/pandas/dist"
+		sh -c "conda build --numpy=1.17.3 --python=3.8 /recipe --output-folder=/pandas/dist"
 
 pip-test: pandas/dist/$(TARGZ)
 	docker run -it --rm \
@@ -82,17 +83,6 @@ pip-test: pandas/dist/$(TARGZ)
 # -----------------------------------------------------------------------------
 # Docs
 # -----------------------------------------------------------------------------
-
-# this had a non-zero exit, but seemed to succeed
-# Output written on pandas.pdf (2817 pages, 10099368 bytes).
-# Transcript written on pandas.log.
-# Traceback (most recent call last):
-#   File "./make.py", line 372, in <module>
-#     sys.exit(main())
-#   ...
-#   File "/opt/conda/envs/pandas/lib/python3.7/subprocess.py", line 347, in check_call
-#     raise CalledProcessError(retcode, cmd)
-# subprocess.CalledProcessError: Command '('pdflatex', '-interaction=nonstopmode', 'pandas.tex')' returned non-zero exit status 1.
 
 doc:
 	docker run -it \
@@ -117,7 +107,9 @@ push-doc: | upload-doc link-stable link-version
 
 website:
 	pushd pandas/web && \
-		./pandas_web.py pandas
+		git checkout master && \
+		git pull && \
+		./pandas_web.py pandas && \
 	popd
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: pandas-release
 channels:
-    - defaults
     - conda-forge
 dependencies:
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ requirements:
   host:
     - python
     - pip
-    - cython
+    - cython >=0.29.13
     - numpy
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - python-dateutil >=2.5.*
-    - pytz
+    - python-dateutil >=2.6.1
+    - pytz >=2017.2
 
 test:
   requires:
@@ -32,7 +32,7 @@ test:
     - pytest-mock
     - hypothesis
   commands:
-    - python -c "import pandas; pandas.test()"
+    - python -c "import pandas; pandas.test(extra_args=['-m not clipboard', '--skip-slow', '--skip-network', '--skip-db'])"
 
 about:
   home: http://pandas.pydata.org

--- a/scripts/conda-forge.sh
+++ b/scripts/conda-forge.sh
@@ -9,8 +9,7 @@ then
 	exit 1
 fi
 
-conda install -y conda-build
-conda install -y -c conda-forge conda-smithy conda-forge-pinning
+conda install -y -c conda-forge conda-build conda-smithy conda-forge-pinning
 
 PANDAS_VERSION="${1:1}"
 PANDAS_SHA=$(openssl dgst -sha256 pandas/dist/pandas-${PANDAS_VERSION}.tar.gz | cut -d ' ' -f 2)

--- a/scripts/pip_test.sh
+++ b/scripts/pip_test.sh
@@ -8,4 +8,4 @@ source activate pip-test
 
 python3 -m pip wheel --no-deps --wheel-dir=/pandas/dist $1
 python3 -m pip install --no-deps --no-index --find-links=/pandas/dist --only-binary=pandas pandas
-python3 -c "import pandas; pandas.test()"
+python3 -c "import pandas; pandas.test(extra_args=['-m not clipboard', '--skip-slow', '--skip-network', '--skip-db'])"

--- a/scripts/wheels.sh
+++ b/scripts/wheels.sh
@@ -22,9 +22,10 @@ git pull upstream
 echo `git status`
 git checkout -B RLS-"${PANDAS_VERSION}"
 
-sed -i 's/BUILD_COMMIT=v.*/BUILD_COMMIT='${PANDAS_VERSION}'/' .travis.yml
+sed -i 's/BUILD_COMMIT: "v.*/BUILD_COMMIT: "'${PANDAS_VERSION}'"/' azure/windows.yml
+sed -i 's/BUILD_COMMIT: "v.*/BUILD_COMMIT: "'${PANDAS_VERSION}'"/' azure/posix.yml
 
-git add .travis.yml
+git add azure
 git commit -m "RLS $PANDAS_VERSION"
 git --no-pager diff HEAD~1
 


### PR DESCRIPTION
Updates for the 1.0.3 release. Includes

* Changes related to the new wheel building (on azure, uploaded to anaconda.org)
* Updates the Conda-test recipe to use Python 3.8
* Skips the clipboard tests, since the docker images don't have the necessary dependencies.