### PR TITLE
add test on docs in the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ pandas/dist/$(TARGZ):
 		-v ${CURDIR}/pandas:/pandas \
 		-v ${CURDIR}/scripts:/scripts \
 		pandas-build \
-		sh /scripts/build_sdist.sh
+		/scripts/build_sdist.sh
 
 # -----------------------------------------------------------------------------
 # Tests

--- a/scripts/build_sdist.sh
+++ b/scripts/build_sdist.sh
@@ -9,3 +9,18 @@ rm -rf dist
 git clean -xfd
 python setup.py clean --quiet
 python setup.py sdist --formats=gztar --quiet
+
+# as of https://github.com/pandas-dev/pandas/pull/38846, docs should not
+# be included in the package tarball
+num_docs_files=$(
+    grep --count -E "^doc" < pandas.egg-info/SOURCES.txt
+)
+if [[ ${num_docs_files} -gt 0 ]]; then
+    echo ""
+    echo "Files from doc/ should not be included in the package, but ${num_docs_files} were found."
+    echo "first few files:"
+    echo ""
+    cat pandas.egg-info/SOURCES.txt | grep -E "^doc" | head -n 20
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
In https://github.com/pandas-dev/pandas/pull/38846, I'm proposing that the contents of `doc/` be removed from package artifacts. See the discussion there and in https://github.com/pandas-dev/pandas/issues/30741 for more background.

During review on that PR, I was asked to include a test here in `pandas-release` to check that docs haven't been inadvertently included in artifacts (https://github.com/pandas-dev/pandas/pull/38846#issuecomment-754337137). This PR proposes that test.

If you run the following

```shell
make init-repos
make docker-image
make pip-test
```

The build will fail with this error

```text
Files from doc/ should not be included in the package, but 223 were found.
first few files:

doc/README.rst
doc/make.py
doc/_templates/autosummary/accessor.rst
doc/_templates/autosummary/accessor_attribute.rst
doc/_templates/autosummary/accessor_callable.rst
doc/_templates/autosummary/accessor_method.rst
doc/_templates/autosummary/class.rst
doc/_templates/autosummary/class_without_autosummary.rst
doc/cheatsheet/Pandas_Cheat_Sheet.pdf
doc/cheatsheet/Pandas_Cheat_Sheet.pptx
doc/cheatsheet/Pandas_Cheat_Sheet_JA.pdf
doc/cheatsheet/Pandas_Cheat_Sheet_JA.pptx
doc/cheatsheet/README.txt
doc/data/fx_prices
doc/data/iris.data
doc/source/conf.py
doc/source/ecosystem.rst
doc/source/index.rst.template
doc/source/_static/index_api.svg
doc/source/_static/index_contribute.svg

Makefile:53: recipe for target 'pandas/dist/pandas-1.1.0.tar.gz' failed
make: *** [pandas/dist/pandas-1.1.0.tar.gz] Error 1
```

This is my first time in this repo, so if I didn't put this test in the right place please let me know.

Thanks!